### PR TITLE
Ability to set relative ruleset path

### DIFF
--- a/.vscode/usersettings.json
+++ b/.vscode/usersettings.json
@@ -9,7 +9,8 @@
     // Set to false to use you own ruleset (set path)
      "apexPMD.useDefaultRuleset": "true",
 
-     // Absolute path to ruleset xml file.  Must also set `useDefaultRuleset:false`.
+    // Path to ruleset xml file.  Must also set `useDefaultRuleset:false`.
+    // If relative, uses currently open directory as a starting point
     "apexPMD.rulesetPath": "",
     
         // Will run static analysis every time a file is opened

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-    "name": "apex-pmd",
-    "version": "0.0.21",
+    "name": "apex-pmd-code-scanner",
+    "version": "0.0.40",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,10 @@ export function activate(context: vscode.ExtensionContext) {
     let config = new Config();
     if(config.useDefaultRuleset){
         config.rulesetPath = context.asAbsolutePath(path.join('rulesets', 'apex_ruleset.xml'));
+    } else {
+        if (!path.isAbsolute(config.rulesetPath) && vscode.workspace.rootPath) {
+            config.rulesetPath = path.join(vscode.workspace.rootPath, config.rulesetPath);
+        }
     }
 
     //setup instance vars


### PR DESCRIPTION
Hi!

Loved the idea, but seems Chuck (the original author) no longer maintains the extension.

I added an ability to set a relative path for rulesets starting from the current workspace dir, cause I want to commit rulesets to repos

Please merge once you are ready 🙂 